### PR TITLE
Add "real" go.mod module so it can get updated by dependabot

### DIFF
--- a/bootstrapper/templatizer.go
+++ b/bootstrapper/templatizer.go
@@ -24,6 +24,12 @@ func (tz Templatizer) FillOutTemplate(path string, config Config) error {
 		return fmt.Errorf("failed to read template file: %w", err)
 	}
 
+	// go.mod file: update the module to use templating so the go.mod will be functional
+	if strings.Contains(path, "go.mod") {
+		newContents := strings.Replace(string(templ), "github.com/test/test", "github.com/{{ .Organization }}/{{ .Buildpack }}", -1)
+		templ = []byte(newContents)
+	}
+
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
 	if err != nil {
 		return fmt.Errorf("failed to open template file: %w", err)

--- a/bootstrapper/templatizer_test.go
+++ b/bootstrapper/templatizer_test.go
@@ -51,6 +51,30 @@ func testTemplatizer(t *testing.T, context spec.G, it spec.S) {
 			Expect(string(contents)).To(Equal("my-bp-name myorg"))
 		})
 
+		context("when the templated file is a go.mod", func() {
+			it.Before(func() {
+				Expect(os.RemoveAll(templatePath)).To(Succeed())
+
+				template, err := ioutil.TempFile("", "go.mod")
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = template.WriteString("module github.com/test/test")
+				Expect(err).NotTo(HaveOccurred())
+
+				templatePath = template.Name()
+			})
+
+			it("templates the module", func() {
+				err := templatizer.FillOutTemplate(templatePath, config)
+				Expect(err).NotTo(HaveOccurred())
+
+				contents, err := ioutil.ReadFile(templatePath)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(string(contents)).To(Equal("module github.com/myorg/my-bp-name"))
+			})
+		})
+
 		context("when the template file uses the RemoveHyphens function", func() {
 			it.Before(func() {
 				Expect(os.RemoveAll(templatePath)).To(Succeed())

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -24,7 +24,7 @@ func TestBootstrapper(t *testing.T) {
 	var err error
 	bootstrapper, err = gexec.Build("github.com/paketo-community/bootstrapper/executer")
 	Expect(err).NotTo(HaveOccurred())
-	SetDefaultEventuallyTimeout(30 * time.Second)
+	SetDefaultEventuallyTimeout(60 * time.Second)
 
 	spec.Run(t, "dispatch", func(t *testing.T, context spec.G, it spec.S) {
 		var (

--- a/template-cnb/go.mod
+++ b/template-cnb/go.mod
@@ -1,4 +1,4 @@
-module github.com/{{ .Organization }}/{{ .Buildpack }}
+module github.com/test/test
 
 go 1.14
 


### PR DESCRIPTION
The `go.mod` inside `template-cnb` used to have `module github.com/{{ .Organization }}/{{ .Buildpack }}` as it's module. Because of this, we can't run `go mod tidy` on it to update the rest of the dependencies. 

This PR makes the top level module `module github.com/test/test` so that Dependabot can see this as a real `go.mod`. It also adds in a line of code to re-add the templating so the resulting bootstrapped CNB has a correct `go.mod`