### PR TITLE
Convert underscores to dashes which aligns with libpak/packit styling

### DIFF
--- a/template-cnb/buildpack.toml
+++ b/template-cnb/buildpack.toml
@@ -9,5 +9,5 @@ api = "0.2"
   id = "io.buildpacks.stacks.bionic"
 
 [metadata]
-  include_files = ["bin/run","bin/build","bin/detect","buildpack.toml"]
-  pre_package = "./scripts/build.sh"
+  include-files = ["bin/run","bin/build","bin/detect","buildpack.toml"]
+  pre-package = "./scripts/build.sh"


### PR DESCRIPTION
Related to https://github.com/paketo-buildpacks/packit/pull/76.

Fixes:

```console
❯ ./scripts/package.sh --version 0.0.1
Preparing repo...
...
Packaging buildpack...
ERROR: creating buildpack from build/buildpack.tgz: reading buildpack.toml: could not find entry path 'buildpack.toml': not exist
```

Signed-off-by: Andrei Krasnitski <a.krasnitski@outlook.com>