### PR TITLE
Add unstable as a valid state for auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -30,7 +30,7 @@ jobs:
         echo "::set-output name=mergeable_state::$(echo "${payload}" | jq -r -c .mergeable_state)"
 
     - name: Merge
-      if: ${{ steps.pull_request.outputs.mergeable_state == 'clean' }}
+      if: ${{ steps.pull_request.outputs.mergeable_state == 'clean' || steps.pull_request.outputs.mergeable_state == 'unstable' }}
       uses: paketo-buildpacks/github-config/actions/pull-request/merge@main
       with:
         user: paketo-bot


### PR DESCRIPTION
This should resolve the issue where bot PRs that are approved are not getting merged, as can be seen here: https://github.com/paketo-community/bootstrapper/pull/93/checks?check_run_id=2579702252