### PR TITLE
Manually add bot PR approval workflow

### DIFF
--- a/.github/workflows/approve-bot-pr.yml
+++ b/.github/workflows/approve-bot-pr.yml
@@ -1,0 +1,62 @@
+name: Approve Bot PRs
+
+on:
+  workflow_run:
+    workflows: ["Test Pull Request"]
+    types:
+      - completed
+
+jobs:
+  download:
+    name: Download PR Artifact
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      pr-author: ${{ steps.pr-data.outputs.author }}
+      pr-number: ${{ steps.pr-data.outputs.number }}
+    steps:
+      - name: 'Download artifact'
+        uses: paketo-buildpacks/github-config/actions/pull-request/download-artifact@main
+        with:
+          name: "event-payload"
+          repo: ${{ github.repository }}
+          run_id: ${{ github.event.workflow_run.id }}
+          workspace: "/github/workspace"
+          token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+      - id: pr-data
+        run: |
+          echo "::set-output name=author::$(cat event.json | jq -r '.pull_request.user.login')"
+          echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
+
+  approve:
+    name: Approve Bot PRs
+    needs: download
+    if: ${{ needs.download.outputs.pr-author == 'paketo-bot' || needs.download.outputs.pr-author == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check Commit Verification
+      id: unverified-commits
+      uses: paketo-buildpacks/github-config/actions/pull-request/check-unverified-commits@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        number: ${{ needs.download.outputs.pr-number }}
+
+    - name: Check for Human Commits
+      id: human-commits
+      uses: paketo-buildpacks/github-config/actions/pull-request/check-human-commits@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        number: ${{ needs.download.outputs.pr-number }}
+
+    - name: Checkout
+      if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
+      uses: actions/checkout@v2
+
+    - name: Approve
+      if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
+      uses: paketo-buildpacks/github-config/actions/pull-request/approve@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
+        number: ${{ needs.download.outputs.pr-number }}

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -41,37 +41,12 @@ jobs:
       env:
         GIT_TOKEN: ${{ github.token }}
 
-  approve:
-    name: Approve Bot PRs
-    if: ${{ github.event.pull_request.user.login == 'paketo-bot' || github.event.pull_request.user.login == 'dependabot[bot]' }}
+  upload:
+    name: Upload Workflow Event Payload
     runs-on: ubuntu-latest
-    needs: integration
     steps:
-    - name: Check Commit Verification
-      id: unverified-commits
-      uses: paketo-buildpacks/github-config/actions/pull-request/check-unverified-commits@main
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
       with:
-        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
-        repo: ${{ github.repository }}
-        number: ${{ github.event.number }}
-
-    - name: Check for Human Commits
-      id: human-commits
-      uses: paketo-buildpacks/github-config/actions/pull-request/check-human-commits@main
-      with:
-        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
-        repo: ${{ github.repository }}
-        number: ${{ github.event.number }}
-
-    - name: Checkout
-      if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
-      uses: actions/checkout@v2
-
-    - name: Auto Approve
-      if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
-      uses: paketo-buildpacks/github-config/actions/pull-request/approve@main
-      with:
-        user: paketo-bot-reviewer
-        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
-        author: ${{ github.event.pull_request.user.login }}
-        number: ${{ github.event.number }}
+        name: event-payload
+        path: ${{ github.event_path }}


### PR DESCRIPTION
We recently updated our repos to use a new bot PR approval workflow with [this PR](https://github.com/paketo-buildpacks/github-config/pull/267).
This PR makes the same change to this repo so that our bot PRs can get automerged.