### PR TITLE
Allow user to pass in tag version in workflows

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
     - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version of the release to cut (e.g. 1.2.3)'
+        required: false
+
+concurrency: release
 
 jobs:
   unit:
@@ -37,11 +44,19 @@ jobs:
       with:
         repo: ${{ github.repository }}
         token: ${{ github.token }}
-    - name: Tag
-      id: tag
+    - name: Increment Tag
+      id: increment
       uses: paketo-buildpacks/github-config/actions/tag/increment-tag@main
       with:
         current_version: ${{ steps.reset.outputs.current_version }}
+    - name: Set Release Tag
+      id: tag
+      run: |
+        tag="${{ github.event.inputs.version }}"
+        if [ -z "${tag}" ]; then
+          tag="${{ steps.increment.outputs.tag }}"
+        fi
+        echo "::set-output name=tag::${tag}"
     - name: Package Bootstrapper
       run : ./scripts/package.sh --version ${{ steps.tag.outputs.tag }}
     - name: Create Draft Release


### PR DESCRIPTION
Allow user to override the release version in the create-draft-release workflow if needed.