### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/approve-bot-pr.yml
+++ b/.github/workflows/approve-bot-pr.yml
@@ -25,8 +25,8 @@ jobs:
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
       - id: pr-data
         run: |
-          echo "::set-output name=author::$(cat event.json | jq -r '.pull_request.user.login')"
-          echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
+          echo "author=$(cat event.json | jq -r '.pull_request.user.login')" >> $GITHUB_OUTPUT
+          echo "number=$(cat event.json | jq -r '.pull_request.number')" >> $GITHUB_OUTPUT
 
   approve:
     name: Approve Bot PRs

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -27,7 +27,7 @@ jobs:
             --header "Authorization: token ${GITHUB_TOKEN}"
         )"
 
-        echo "::set-output name=mergeable_state::$(echo "${payload}" | jq -r -c .mergeable_state)"
+        echo "mergeable_state=$(echo "${payload}" | jq -r -c .mergeable_state)" >> $GITHUB_OUTPUT
 
     - name: Merge
       if: ${{ steps.pull_request.outputs.mergeable_state == 'clean' || steps.pull_request.outputs.mergeable_state == 'unstable' }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -56,7 +56,7 @@ jobs:
         if [ -z "${tag}" ]; then
           tag="${{ steps.increment.outputs.tag }}"
         fi
-        echo "::set-output name=tag::${tag}"
+        echo "tag=${tag}" >> $GITHUB_OUTPUT
     - name: Package Bootstrapper
       run : ./scripts/package.sh --version ${{ steps.tag.outputs.tag }}
     - name: Create Draft Release


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


